### PR TITLE
Facebook login/register v2.4+ compatibility

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/Model/Facebook/Info.php
+++ b/app/code/community/Inchoo/SocialConnect/Model/Facebook/Info.php
@@ -33,17 +33,7 @@
 
 class Inchoo_SocialConnect_Model_Facebook_Info extends Varien_Object
 {
-    protected $params = array(
-        'id',
-        'name',
-        'first_name',
-        'last_name',
-        'link',
-        'birthday',
-        'gender',
-        'email',
-        'picture.type(large)'
-    );
+    protected $params = array('fields' => 'id,name,first_name,last_name,link,birthday,gender,email,picture.type(large)');
 
     /**
      * Facebook client model


### PR DESCRIPTION
This fixes (again) the 'Sorry, could not retrieve your Facebook first name'.
The way you should request the fields from the facebook API was changed from v2.3 to v2.4. See  https://developers.facebook.com/docs/apps/changelog/#v2_4

The connector does not pass a specific version for the API. So it will try to connect to the oldest available API. But the oldest API depends on the time that your facebook app was created. See https://developers.facebook.com/docs/apps/versions#calling_older_versions.

I changed the way the params are passed to the API . This change seems backwards compatible with version v2.3 and older. 
